### PR TITLE
[VIM] set tab size from four to two spaces

### DIFF
--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -31,8 +31,8 @@ filetype plugin indent on    " required
 " Put your non-Plugin stuff after this line
 
 filetype plugin indent on
-set tabstop=4
-set shiftwidth=4
+set tabstop=2
+set shiftwidth=2
 set expandtab
 
 " preserve initial EOL setting


### PR DESCRIPTION
Easier to hit tab twice when four spaces are needed vs having to backspace twice when two spaces are needed.
